### PR TITLE
Update chat.sql

### DIFF
--- a/sql/chat.sql
+++ b/sql/chat.sql
@@ -11,8 +11,7 @@ CREATE SEQUENCE chat_room_seq;
 CREATE TABLE chat_join(
 	member_id REFERENCES member(member_id) ON DELETE SET NULL,
 	chat_room_no NUMBER REFERENCES chat_room(chat_room_no) ON DELETE CASCADE,
-	chat_join_time DATE DEFAULT sysdate NOT NULL,
-	PRIMARY KEY(chat_room_no, member_id)
+	chat_join_time DATE DEFAULT sysdate NOT NULL
 );
 
 -- 채팅 메세지
@@ -32,8 +31,7 @@ CREATE TABLE chat_read(
 	chat_room_no REFERENCES chat_room(chat_room_no) ON DELETE CASCADE,
 	chat_message_no REFERENCES chat_message(chat_message_no) ON DELETE CASCADE,
 	chat_sender REFERENCES member(member_id) ON DELETE SET NULL,
-	chat_reciever varchar2(20) NOT NULL,
-	chat_read_time DATE DEFAULT sysdate
+	chat_reciever varchar2(20) NOT NULL
 );
 
 -- 채팅 좋아요


### PR DESCRIPTION
채팅 참여 테이블 PK 삭제
- member_id가 PK로 설정되어있으면 null이 될 수 없어서 회원 탈퇴 불가

채팅 전송 테이블 읽은 시간 컬럼 삭제
- 읽으면 데이터를 삭제하는 방향으로 구상중